### PR TITLE
Add wagtail 7 support, drop django 4.0 and python 3.8 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* Wagtail 7.0 & 7.1 maintenance
+
 ## 1.0.0 (16.12.2024)
 
 * **Breaking**: Callables passed as `PARENT_PAGE_ID` no longer accept an `instance` argument (Matt Westcott)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,25 +22,26 @@ classifiers=[
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Framework :: Django",
-    "Framework :: Django :: 4",
-    "Framework :: Django :: 5.0",
+    "Framework :: Django :: 4.2",
     "Framework :: Django :: 5.1",
+    "Framework :: Django :: 5.2",
     "Framework :: Wagtail",
     "Framework :: Wagtail :: 5",
     "Framework :: Wagtail :: 6",
+    "Framework :: Wagtail :: 7",
 ]
 
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
-    "Wagtail>=5.2",
+    "Wagtail>=6.3",
     "Django>=4.2",
-    "pyairtable>=2.3,<3",
-    "djangorestframework>=3.11.0"
+    "pyairtable>=3,<4",
+    "djangorestframework>=3.16.1"
 ]
 
 [project.optional-dependencies]
 testing = [
-    "tox>=3.27"
+    "tox>=4.30.2"
 ]
 
 [project.urls]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 envlist =
-    python{3.9,3.10,3.11,3.12,3.13}-django{4.2,5.0,5.1}-wagtail{5.2,6.0,6.1,6.2,6.3}
+    python{3.9,3.10,3.11,3.12}-django{4.2}-wagtail{6.3,7.0,7.1}
+    python{3.10,3.11,3.12,3.13}-django{5.1,5.2}-wagtail{6.3,7.0,7.1}
 
 [testenv]
 commands = python runtests.py
@@ -14,10 +15,8 @@ basepython =
 
 deps =
     django4.2: Django>=4.2,<5.0
-    django5.0: Django>=5.0,<5.1
-    django5.0: Django>=5.1,<5.2
-    wagtail5.2: wagtail>=5.2,<6.0
-    wagtail6.0: wagtail>=6.0,<6.1
-    wagtail6.1: wagtail>=6.1,<6.2
-    wagtail6.2: wagtail>=6.2,<6.3
+    django5.1: Django>=5.1,<5.2
+    django5.2: Django>=5.2,<5.3
     wagtail6.3: wagtail>=6.3,<6.4
+    wagtail7.0: wagtail>=7.0,<7.1
+    wagtail7.1: wagtail>=7.1,<7.2


### PR DESCRIPTION
This pull request updates the project to add support for Wagtail 7.0 and 7.1

Dependency and compatibility updates:

* Updated `pyproject.toml` to require `Wagtail>=6.3`, `Django>=4.2`, `pyairtable>=3,<4`, and `djangorestframework>=3.16.1`. The minimum Python version is now 3.9. Added support for Django 5.2 and Wagtail 7 in the project classifiers.
* Updated the test matrix in `tox.ini` to test against Wagtail 7.0 and 7.1, and Django 5.2. Dropped support for Django 5.0 and older Wagtail versions.
* Adjusted dependency groups in `tox.ini` to match the new supported versions of Django and Wagtail.

Documentation:

* Added a changelog entry for Wagtail 7.0 & 7.1 maintenance in `CHANGELOG.md`.